### PR TITLE
Aspell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PLUGIN_NAME = spell
 
 NAME = pop-launcher-plugin-$(PLUGIN_NAME)
-VERSION = 0.1
+VERSION = 0.2
 PKG_VERSION = 1
 ARCH = all
 PKG_NAME = $(NAME)_$(VERSION)-$(PKG_VERSION)_$(ARCH).deb
@@ -11,6 +11,9 @@ install:
 	mkdir -p $(LOCAL_PLUGIN_DIR)/$(PLUGIN_NAME)
 	cp -r src/* $(LOCAL_PLUGIN_DIR)/$(PLUGIN_NAME)
 	chmod +x $(LOCAL_PLUGIN_DIR)/$(PLUGIN_NAME)
+
+uninstall:
+	rm -rfv $(LOCAL_PLUGIN_DIR)/$(PLUGIN_NAME)
 
 BIN_DIR = usr/lib/pop-launcher/plugins/$(PLUGIN_NAME)
 deb_package:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # pop-launcher-plugin-spell
-A spell checking plugin for [pop-launcher](https://github.com/pop-os/launcher) using [hunspell](https://github.com/hunspell/hunspell). Searches for the closest matching spelling and copies it to your clipboard 
+A spell checking plugin for [pop-launcher](https://github.com/pop-os/launcher) using [aspell](https://github.com/GNUAspell/aspell). Searches for the closest matching spelling and copies it to your clipboard 
 
 ### Dependencies
-[hunspell](https://github.com/hunspell/hunspell)\
-Debian/Ubuntu and derivatives - `sudo apt install hunspell`\
-Nix package - `nix-env -iA nixpkgs.hunspell`
+[aspell](https://github.com/GNUAspell/aspell)\
+This is preinstalled in Pop!_OS and most other Linux distributions
+Debian/Ubuntu and derivatives - `sudo apt install aspell`\
+Nix package - `nix-env -iA nixpkgs.aspell`
 
 [xclip](https://github.com/astrand/xclip)\
 Required for copying to the clipboard\
@@ -12,15 +13,14 @@ Debian/Ubuntu and derivatives - `sudo apt install xclip`\
 Nix package - `nix-env -iA nixpkgs.xclip`
 
 ### Installation
-For user installation, clone the repo and run `make install`. Make sure the dependencies are installed\
+For user installation, clone the repo and run `make install` inside the repo's folder. Make sure the dependencies are installed\
+Uninstall with `make uninstall` when in the repo's folder
+
 For system-wide installation, download and install the deb file
 
 ### Usage
 In pop launcher type spell followed by your query to search for the closest matching spelling. Pressing enter copies the result into the clipboard.
 
-### Known issues
-For a lot of cases where a word has a suffix, the plugin assumes the spelling is incorrect even when there is no spelling error, and will offer the same word without the suffix. This is an issue with hunspell. To solve this, hunspell will be replaced with aspell. aspell would be preferable anyway since it is pre-installed in Pop!_OS, and hunspell was only chosen as this plugin was inspired by an equivalent plugin for Albert launcher which used hunspell
-
 ### Todo
-- [ ] Replace hunspell with aspell
+- [x] Replace hunspell with aspell
 - [ ] Modify the GitHub action for creating a deb package to be closer to the method used for packaging for debian repos

--- a/debian/control
+++ b/debian/control
@@ -1,9 +1,9 @@
 Package: pop-launcher-plugin-spell
-Version: 0.1
+Version: 0.2
 Architecture: all
 Section: misc
 Essential: no
 Priority: optional
-Depends: pop-launcher, hunspell, xclip
+Depends: pop-launcher, xclip
 Maintainer: Faris Redza <faris.redza1999@gmail.com>
-Description: A spell checking plugin for pop-launcher using hunspell as a backend.
+Description: A spell checking plugin for pop-launcher using aspell as a backend

--- a/src/spell
+++ b/src/spell
@@ -8,10 +8,6 @@ class App(object):
     def __init__(self):
         self.match = None
 
-    h = 'Hunspell'
-    find_version = os.popen('hunspell -v').read()
-    version = find_version[find_version.find(h)+len(h):find_version.find(h)+len(h)+6]
-
     def activate(self, index):
         if not self.matches:
             return
@@ -24,9 +20,7 @@ class App(object):
         sys.stdout.flush()
 
     def search_word(self, query):
-        response = os.popen(f'echo {query} | hunspell').read()
-
-        response = response.strip(f'{self.h} + {self.version}\n')
+        response = os.popen(f'echo {query} | aspell -a | tail -n +2').read()
 
         startLocation = response.find(":") + 1
         response = response[startLocation:None]


### PR DESCRIPTION
This pull request replaces hunspell with aspell, due to hunspell's issues with suffixes. Aspell is also preferable as it is preinstalled in Pop!_OS and most other distributions, meaning one less dependency that needs to be installed.
This also simplifies the response stripping to remove unnecessary output when calling hunspell/aspell